### PR TITLE
Possibility to get direct rxdart stream to avoid memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.3.15
+* provide option to listen on source location stream which doesn't cause memory leaks
+
 ## 2.3.14
 * upgrade dependencies  
 * fix for query results duplicate after 1250km as described in [this issue](https://github.com/beerstorm-net/GeoFlutterFire2/issues/13)  

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Calling `geoFirePoint.data` returns an object that contains a [geohash string](h
 ![](https://firebasestorage.googleapis.com/v0/b/geo-test-c92e4.appspot.com/o/point1.png?alt=media&token=0c833700-3dbd-476a-99a9-41c1143dbe97)
 
 ## Query Geo data
+> **Warning**
+> Querying locations creates 9 separated stream listeners on firestore. One for central geo hash and 8 surrounding it.
+> `within` function creates a convenient broadcast stream, if you need more than one subscriber for the locations. But it also causes
+> memory leak, because underlying stream listeners are not cancelled when you cancel StreamSubscription from `within` method.
+> 
+> It's much safer to use withinAsSingleStreamSubscription which you can cancel, and it will also cancel 9 underlying streams as well.
 
 To query a collection of documents with 50kms from a point
 


### PR DESCRIPTION
Possibility to use the library without memory leak that is caused by not cancelling stream subscriptions for merged streams from rxdart. No breaking changes, I kept current behaviour so to not break it work users.

Basically, creating broadcast stream and cancelling it does not nothing on the stream controller which is created in rxdart: https://github.com/dart-lang/sdk/issues/26686#issuecomment-225346901

The other way to fix it would be extend rxdart about possibility to return stream controller, and return both, broadcast stream and controller so user have full control over what is going down the path. But this could be overkill, and requires rxdart changes (tested that solution already). But, anyway, since we need to change the geo hash center position to start listening for different region, I would suggest using stream from rxdart directly.
The only thing that above is doesn't suits is when user need to have listener in couple places (different views for instance). But this also could be done by user by have single central place of the stream consumer.