### PR TITLE
new function to retrieve documents

### DIFF
--- a/lib/src/collection.dart
+++ b/lib/src/collection.dart
@@ -78,7 +78,7 @@ class GeoFireCollectionRef {
   }
 
   /// Query firestore documents based on geographic [radius] in kilometers from geoFirePoint [center]
-  /// [field] specifies the name of the key that contains "geohash" key
+  /// [field] specifies the name of the key that contains "geohash" and "geopoint" keys in the document
   /// returns the list of [DocumentSnapshot]
   ///
   /// Use [strictMode] parameter to filter by distance from center
@@ -205,7 +205,7 @@ class GeoFireCollectionRef {
   }
 
   /// Query firestore documents based on geographic [radius] in kilometers from geoFirePoint [center]
-  /// [field] specifies the name of the key that contains "geohash" key in the document
+  /// [field] specifies the name of the key that contains "geohash" and "geopoint" keys in the document
   /// returns merged stream as broadcast stream.
   ///
   /// Use [strictMode] parameter to filter by distance from center
@@ -231,7 +231,7 @@ class GeoFireCollectionRef {
   }
 
   /// Query firestore documents based on geographic [radius] in kilometers from geoFirePoint [center]
-  /// [field] specifies the name of the key in the document
+  /// [field] specifies the name of the key that contains "geohash" and "geopoint" keys in the document
   /// returns merged stream as broadcast stream.
   ///
   /// !WARNING! This causes memory leaks because under the hood rxdart StreamController

--- a/lib/src/collection.dart
+++ b/lib/src/collection.dart
@@ -146,7 +146,7 @@ class GeoFireCollectionRef {
     return filtered;
   }
 
-  /// Query firestore documents based on geographic [radius] from geoFirePoint [center]
+  /// Query firestore documents based on geographic [radius] in kilometers from geoFirePoint [center]
   /// [field] specifies the name of the key in the document
   /// returns merged stream as broadcast stream.
   ///
@@ -170,7 +170,7 @@ class GeoFireCollectionRef {
     );
   }
 
-  /// Query firestore documents based on geographic [radius] from geoFirePoint [center]
+  /// Query firestore documents based on geographic [radius] in kilometers from geoFirePoint [center]
   /// [field] specifies the name of the key in the document
   /// returns merged stream as broadcast stream.
   ///


### PR DESCRIPTION
The unit of the radius has to be indicated in the function descriptions in order to prevent enormous document reads by mistake. I thought it was meter based and so mistakenly filled my quota

Documents now can be retrieved without stream subscription or snapshot listening. Streamful functions and snapshot listeners should be focused more on real-time tracking.

[Warning] `getDocumentsWithin` function is not tested